### PR TITLE
fix: import esbuild as default

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -39,7 +39,7 @@ function timer() {
 	console.log('~> created "%s" file (%s)', outfile, t());
 
 	t = timer(); // types
-	await run(`yarn tsc src/index.ts -d --declarationDir . --emitDeclarationOnly`);
+	await run(`yarn tsc src/index.ts -d --declarationDir . --emitDeclarationOnly --allowSyntheticDefaultImports`);
 	console.log('~> created "%s" file (%s)', pkg.types, t());
 })().catch(err => {
 	console.error('ERROR', err.stack || err);

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "build": "node bin",
-    "pretest": "tsc src/index.ts --noEmit",
+    "pretest": "tsc src/index.ts --noEmit  --allowSyntheticDefaultImports",
     "test": "uvu test -i \"register|fixtures\" -r test/register"
   },
   "engines": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { readFile, existsSync } from 'fs';
 import { dirname, resolve } from 'path';
-import * as esbuild from 'esbuild';
+import esbuild from 'esbuild';
 import { promisify } from 'util';
 
 const read = promisify(readFile);


### PR DESCRIPTION
**edit: happily this isn't needed when esbuild is upgraded to 0.9 - see the last comment below**

This fixes the ESM import of `esbuild` as described in #4 and has the identical fix that @henriquehbr described. This does not close the issue - it only fixes the ESM import, not the use of `require` in a module.

If I were technoking I'm not sure we'd have these synthetic export things but oh well.