### PR TITLE
chore: upgrade to esbuild 0.9.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,12 +32,12 @@
     "dist"
   ],
   "peerDependencies": {
-    "esbuild": ">=0.8.28",
+    "esbuild": ">=0.9.0",
     "svelte": ">=3.5.0"
   },
   "devDependencies": {
     "@types/node": "14.14.13",
-    "esbuild": "0.8.29",
+    "esbuild": "^0.9.2",
     "premove": "3.0.1",
     "rewrite-imports": "2.0.3",
     "svelte": "3.31.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@types/node": "14.14.13",
-    "esbuild": "^0.9.2",
+    "esbuild": "^0.9.3",
     "premove": "3.0.1",
     "rewrite-imports": "2.0.3",
     "svelte": "3.31.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@types/node": "14.14.13",
-    "esbuild": "^0.9.3",
+    "esbuild": "0.9.3",
     "premove": "3.0.1",
     "rewrite-imports": "2.0.3",
     "svelte": "3.31.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,14 +5,14 @@ import { promisify } from 'util';
 
 const read = promisify(readFile);
 
-import type { Service, TransformOptions } from 'esbuild';
+import type { TransformOptions } from 'esbuild';
 import type { PreprocessorGroup, Processed } from 'svelte/types/compiler/preprocess';
 
 export type Definitions = {
 	[find: string]: string;
 }
 
-type Allow = Pick<TransformOptions, 'avoidTDZ'|'banner'|'charset'|'define'|'footer'|'keepNames'|'pure'|'target'|'treeShaking'|'tsconfigRaw'>;
+type Allow = Pick<TransformOptions, 'banner'|'charset'|'define'|'footer'|'keepNames'|'pure'|'target'|'treeShaking'|'tsconfigRaw'>;
 
 export interface Options extends Allow {
 	/** @default 'tsconfig.json' */
@@ -39,24 +39,6 @@ type Negate<U, T> = U extends T ? never : U;
 type TSConfig = Negate<TransformOptions['tsconfigRaw'], string> & { extends?: boolean };
 
 // ---
-
-let decided = false;
-let service: Service | null;
-
-function isWatcher(): boolean {
-	const { ROLLUP_WATCH, WEBPACK_DEV_SERVER, CI, NODE_ENV } = process.env;
-
-	if (CI != null) return false;
-	if (ROLLUP_WATCH || WEBPACK_DEV_SERVER) return true;
-	return !/^(prod|test)/.test(NODE_ENV) && /^(dev|local)/.test(NODE_ENV);
-}
-
-async function decide() {
-	decided = true;
-	if (isWatcher()) {
-		service = await esbuild.startService();
-	}
-}
 
 const isExternal = /^(https?:)?\/\//;
 const isString = (x: unknown): x is string => typeof x === 'string';
@@ -92,7 +74,7 @@ async function transform(input: ProcessorInput, options: TransformOptions): Prom
 		}
 	}
 
-	let output = await (service || esbuild).transform(input.content, config);
+	let output = await esbuild.transform(input.content, config);
 
 	// TODO: format output.warnings
 	if (output.warnings.length > 0) {
@@ -118,7 +100,7 @@ export function typescript(options: Partial<Options> = {}): PreprocessorGroup {
 		loader: 'ts',
 		format: 'esm',
 		minify: false,
-		errorLimit: 0,
+		logLimit: 0,
 	};
 
 	let contents: TSConfig;
@@ -154,8 +136,6 @@ export function typescript(options: Partial<Options> = {}): PreprocessorGroup {
 
 	return {
 		async script(input) {
-			decided || await decide();
-
 			let bool = !!isTypescript(input.attributes);
 			if (!bool && !!define) return transform(input, { define, loader: 'js' });
 			if (!bool) return { code: input.content };
@@ -173,8 +153,6 @@ export function replace(define: Definitions = {}): PreprocessorGroup {
 
 	return {
 		async script(input) {
-			decided || await decide();
-
 			let bool = !!isTypescript(input.attributes);
 			if (bool) return { code: input.content };
 


### PR DESCRIPTION
This upgrades to esbuild 0.9.3 (latest). I'm not sure what your upgrade plans were, so no worries if you want to close this.

release notes: https://github.com/evanw/esbuild/releases/tag/v0.9.0

I think I got everything:

- bump esbuild dependency to 0.9.3 (and make peer dep >=0.9)
- use `esbuild.transform` after `startService` was removed and remove its async helper code
- rename `errorLimit` to `logLimit`
- delete removed option `avoidTDZ`