### PR TITLE
Update for esbuild >= 0.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "dist"
   ],
   "peerDependencies": {
-    "esbuild": ">=0.9.0",
+    "esbuild": ">=0.14.0",
     "svelte": ">=3.5.0"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -128,8 +128,8 @@ export function typescript(options: Partial<Options> = {}): PreprocessorGroup {
 	}
 
 	let compilerOptions = { ...contents.compilerOptions };
-	// @see https://github.com/evanw/esbuild/releases/tag/v0.8.28
-	compilerOptions.importsNotUsedAsValues = 'preserve';
+	// @see https://github.com/evanw/esbuild/releases/tag/v0.14.0
+	compilerOptions.preserveValueImports = true;
 	config.tsconfigRaw = { compilerOptions };
 
 	const define = config.define;


### PR DESCRIPTION
Firstly, thanks for your work on this project! I've been using it for a few months, but after upgrading my build tooling, I've been getting dozens of these warnings:

```
# imagine variations of this line repeated dozens of times
[vite-plugin-svelte] /src/client/components/FilterList.svelte:28:13 'Button' is not defined
```

Today, I finally had time to dig deeper and submit a fix.

Previously, the code used `importsNotUsedAsValues` to make sure that esbuild doesn't remove imports that are only used in the Svelte template. 

Because of the new [type modifiers on import names in TypeScript 4.5](https://devblogs.microsoft.com/typescript/announcing-typescript-4-5/#type-on-import-names), this does no longer prevent imports from getting removed. Instead, we need to use `preserveValueImports`.

After finding this, the fix was pretty small. I also adjusted the comment to point to the new release of esbuild, and updated the version defined in the peer dependency.

Thanks for your consideration!